### PR TITLE
internal/engine/interpreter: add support for api Metering

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -416,6 +416,12 @@ type Function interface {
 	internalapi.WazeroOnly
 }
 
+// Meter collects the cost for a set of operations.
+type Meter interface {
+	AddCost(string)
+	GetCost() uint64
+}
+
 // GoModuleFunction is a Function implemented in Go instead of a wasm binary.
 // The Module parameter is the calling module, used to access memory or
 // exported functions. See GoModuleFunc for an example.

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -650,8 +650,10 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, m *wasm.ModuleInstance
 	ce.pushFrame(frame)
 	body := frame.f.parent.body
 	bodyLen := uint64(len(body))
+	sctx := m.Sys
 	for frame.pc < bodyLen {
 		op := &body[frame.pc]
+		sctx.AddMeterCost(op.String())
 		// TODO: add description of each operation/case
 		// on, for example, how many args are used,
 		// how the stack is modified, etc.

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -22,7 +22,7 @@ func TestContext_WalltimeNanos(t *testing.T) {
 func TestDefaultSysContext(t *testing.T) {
 	testFS := &sysfs.AdaptFS{FS: fstest.FS}
 
-	sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, nil, 0, nil, nil, []experimentalsys.FS{testFS}, []string{"/"}, nil)
+	sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, nil, 0, nil, nil, []experimentalsys.FS{testFS}, []string{"/"}, nil, nil)
 	require.NoError(t, err)
 
 	require.Nil(t, sysCtx.Args())
@@ -93,7 +93,7 @@ func TestNewContext_Args(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			sysCtx, err := NewContext(tc.maxSize, tc.args, nil, bytes.NewReader(make([]byte, 0)), nil, nil, nil, nil, 0, nil, 0, nil, nil, nil, nil, nil)
+			sysCtx, err := NewContext(tc.maxSize, tc.args, nil, bytes.NewReader(make([]byte, 0)), nil, nil, nil, nil, 0, nil, 0, nil, nil, nil, nil, nil, nil)
 			if tc.expectedErr == "" {
 				require.Nil(t, err)
 				require.Equal(t, tc.args, sysCtx.Args())
@@ -143,7 +143,7 @@ func TestNewContext_Environ(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			sysCtx, err := NewContext(tc.maxSize, nil, tc.environ, bytes.NewReader(make([]byte, 0)), nil, nil, nil, nil, 0, nil, 0, nil, nil, nil, nil, nil)
+			sysCtx, err := NewContext(tc.maxSize, nil, tc.environ, bytes.NewReader(make([]byte, 0)), nil, nil, nil, nil, 0, nil, 0, nil, nil, nil, nil, nil, nil)
 			if tc.expectedErr == "" {
 				require.Nil(t, err)
 				require.Equal(t, tc.environ, sysCtx.Environ())
@@ -179,7 +179,7 @@ func TestNewContext_Walltime(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, tc.time, tc.resolution, nil, 0, nil, nil, nil, nil, nil)
+			sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, tc.time, tc.resolution, nil, 0, nil, nil, nil, nil, nil, nil)
 			if tc.expectedErr == "" {
 				require.Nil(t, err)
 				require.Equal(t, tc.time, sysCtx.walltime)
@@ -215,7 +215,7 @@ func TestNewContext_Nanotime(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, tc.time, tc.resolution, nil, nil, nil, nil, nil)
+			sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, tc.time, tc.resolution, nil, nil, nil, nil, nil, nil)
 			if tc.expectedErr == "" {
 				require.Nil(t, err)
 				require.Equal(t, tc.time, sysCtx.nanotime)
@@ -260,14 +260,14 @@ func Test_clockResolutionInvalid(t *testing.T) {
 
 func TestNewContext_Nanosleep(t *testing.T) {
 	var aNs sys.Nanosleep = func(int64) {}
-	sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, nil, 0, aNs, nil, nil, nil, nil)
+	sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, nil, 0, aNs, nil, nil, nil, nil, nil)
 	require.Nil(t, err)
 	require.Equal(t, aNs, sysCtx.nanosleep)
 }
 
 func TestNewContext_Osyield(t *testing.T) {
 	var oy sys.Osyield = func() {}
-	sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, nil, 0, nil, oy, nil, nil, nil)
+	sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, nil, 0, nil, oy, nil, nil, nil, nil)
 	require.Nil(t, err)
 	require.Equal(t, oy, sysCtx.osyield)
 }

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -154,7 +154,8 @@ func (m *ModuleInstance) ensureResourcesClosed(ctx context.Context) (err error) 
 		if err = sysCtx.FS().Close(); err != nil {
 			return err
 		}
-		m.Sys = nil
+		// TODO: ensure proper handling
+		// m.Sys = nil
 	}
 
 	if m.CodeCloser == nil {


### PR DESCRIPTION
This PR adds a new interface api.Meter and implementation for providing metering support for the interpreter engine