### PR TITLE
[metering]: return error to Call on failure

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -418,8 +418,7 @@ type Function interface {
 
 // Meter collects the cost for a set of operations.
 type Meter interface {
-	AddCost(string)
-	GetCost() uint64
+	AddCost(context.Context, string) error
 }
 
 // GoModuleFunction is a Function implemented in Go instead of a wasm binary.

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -544,7 +544,9 @@ func (ce *callEngine) call(ctx context.Context, params, results []uint64) (_ []u
 		defer done()
 	}
 
-	ce.callFunction(ctx, m, ce.f)
+	if err := ce.callFunction(ctx, m, ce.f);err != nil {
+		return nil, err
+	}
 
 	// This returns a safe copy of the results, instead of a slice view. If we
 	// returned a re-slice, the caller could accidentally or purposefully
@@ -599,14 +601,17 @@ func (ce *callEngine) recoverOnCall(ctx context.Context, m *wasm.ModuleInstance,
 	return
 }
 
-func (ce *callEngine) callFunction(ctx context.Context, m *wasm.ModuleInstance, f *function) {
+func (ce *callEngine) callFunction(ctx context.Context, m *wasm.ModuleInstance, f *function) error {
 	if f.parent.hostFn != nil {
 		ce.callGoFuncWithStack(ctx, m, f)
 	} else if lsn := f.parent.listener; lsn != nil {
-		ce.callNativeFuncWithListener(ctx, m, f, lsn)
+		if _, err := ce.callNativeFuncWithListener(ctx, m, f, lsn); err != nil {
+			return err
+		}
 	} else {
-		ce.callNativeFunc(ctx, m, f)
+		return ce.callNativeFunc(ctx, m, f)
 	}
+	return nil
 }
 
 func (ce *callEngine) callGoFunc(ctx context.Context, m *wasm.ModuleInstance, f *function, stack []uint64) {
@@ -637,7 +642,7 @@ func (ce *callEngine) callGoFunc(ctx context.Context, m *wasm.ModuleInstance, f 
 	}
 }
 
-func (ce *callEngine) callNativeFunc(ctx context.Context, m *wasm.ModuleInstance, f *function) {
+func (ce *callEngine) callNativeFunc(ctx context.Context, m *wasm.ModuleInstance, f *function) error {
 	frame := &callFrame{f: f, base: len(ce.stack)}
 	moduleInst := f.moduleInstance
 	functions := moduleInst.Engine.(*moduleEngine).functions
@@ -653,7 +658,9 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, m *wasm.ModuleInstance
 	sctx := m.Sys
 	for frame.pc < bodyLen {
 		op := &body[frame.pc]
-		sctx.AddMeterCost(op.String())
+		if err := sctx.AddMeterCost(ctx, op.String()); err != nil {
+			return err
+		}
 		// TODO: add description of each operation/case
 		// on, for example, how many args are used,
 		// how the stack is modified, etc.
@@ -3909,6 +3916,8 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, m *wasm.ModuleInstance
 		}
 	}
 	ce.popFrame()
+
+	return nil
 }
 
 func WasmCompatMax32bits(v1, v2 uint32) uint64 {
@@ -4107,15 +4116,17 @@ func i32Abs(v uint32) uint32 {
 	}
 }
 
-func (ce *callEngine) callNativeFuncWithListener(ctx context.Context, m *wasm.ModuleInstance, f *function, fnl experimental.FunctionListener) context.Context {
+func (ce *callEngine) callNativeFuncWithListener(ctx context.Context, m *wasm.ModuleInstance, f *function, fnl experimental.FunctionListener) (context.Context, error) {
 	def, typ := f.definition(), f.funcType
 
 	ce.stackIterator.reset(ce.stack, ce.frames, f)
 	fnl.Before(ctx, m, def, ce.peekValues(len(typ.Params)), &ce.stackIterator)
 	ce.stackIterator.clear()
-	ce.callNativeFunc(ctx, m, f)
+	if err := ce.callNativeFunc(ctx, m, f); err != nil {
+		return nil, err
+	}
 	fnl.After(ctx, m, def, ce.peekValues(len(typ.Results)))
-	return ctx
+	return ctx, nil
 }
 
 // popMemoryOffset takes a memory offset off the stack for use in load and store instructions.

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -1,6 +1,7 @@
 package sys
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -112,11 +113,11 @@ func (c *Context) RandSource() io.Reader {
 }
 
 // AddMeterCost increments the total based on the cost of an operation.
-func (c *Context) AddMeterCost(op string) int {
+func (c *Context) AddMeterCost(ctx context.Context, op string) error {
 	if c.meter != nil {
-		c.meter.AddCost(op)
+		return c.meter.AddCost(ctx, op)
 	}
-	return 0
+	return nil
 }
 
 // DefaultContext returns Context with no values set except a possible nil


### PR DESCRIPTION
This PR improves error handling for metering allowing for an error returned from the meter to propagate back through `Call`